### PR TITLE
change url of owid from github to the covid.ourworldindata.org link

### DIFF
--- a/processdata/getdata.py
+++ b/processdata/getdata.py
@@ -36,13 +36,13 @@ def daily_report(date_string=None):
 def daily_confirmed():
     # returns the daily reported cases for respective date, 
     # segmented globally and by country
-    df = pd.read_csv('https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/ecdc/new_cases.csv')
+    df = pd.read_csv('https://covid.ourworldindata.org/data/ecdc/new_cases.csv')
     return df
 
 
 def daily_deaths():
     # returns the daily reported deaths for respective date, 
-    df = pd.read_csv('https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/ecdc/new_deaths.csv')
+    df = pd.read_csv('https://covid.ourworldindata.org/data/ecdc/new_deaths.csv')
     return df
 
 


### PR DESCRIPTION
In [OWID readme
](https://github.com/owid/covid-19-data/blob/master/public/data/README.md) they mentioned that in order to use more stable api, use their covid.ourworldindata.org url so create this commit to update that